### PR TITLE
Add Contribution Tab

### DIFF
--- a/tab_contribute.md
+++ b/tab_contribute.md
@@ -1,0 +1,135 @@
+---
+
+title: Contribute
+displaytext: Contribution
+layout: col-sidebar
+tab: true
+order: 6
+tags: Seoul
+
+---
+
+## Contributors
+
+OWASP 서울 챕터와 함께 안전한 소프트웨어 세상을 만들어갈 기여자들을 모집합니다! OWASP(The Open Worldwide Application Security Project) 서울 챕터는 웹 애플리케이션 보안의 중요성을 알리고, 개발자, 보안 전문가, 그리고 학생 등 누구나 참여하여 배우고 교류할 수 있는 열린 커뮤니티입니다.
+
+- **누구나** — 회원이거나 운영진이 아니어도 상관 없어요!
+- **작은 것이라도** — 사소한 아이디어와 행동도 모두 환영합니다.
+- **허락은 필요 없어요** — 커뮤니티에 도움이 된다면 바로 시작하세요!
+
+---
+
+## 기여 방법 안내
+
+### 발표로 지식과 경험 공유
+
+OWASP Seoul Chapter는 매달 마지막 주 화요일 저녁 7시, 서울 강남에서 학생부터 CTO까지 다양한 분들의 발표 세션을 진행합니다. 보안 분야의 경험과 인사이트를 공유해 주세요!
+
+- [발표자 신청 폼](https://docs.google.com/forms/d/e/1FAIpQLSfEcg5id79GXb8I6F3S09B2PYxJ4zsqBTxDscm5nAfI1CH7Cw/viewform) — 직접 발표자로 신청
+- (작성중) 발표 주제 추천
+- (작성중) 주변 연사 추천
+- [MeetUp](https://www.meetup.com/owasp-seoul/) — 세션 일정 확인 및 청중 참여
+- [OWASP Seoul YouTube](https://www.youtube.com/@OWASPSeoul) — 모든 발표 영상 아카이브
+
+### 세미나 참여
+
+- [MeetUp](https://www.meetup.com/owasp-seoul/) — 오프라인 세션 일정 확인 및 참가 신청
+
+### 월간 회의 참여
+
+매월 첫째 주 수요일 오후 8시, Zoom을 통해 온라인 월간 정기 회의를 진행합니다. 운영진뿐 아니라 누구나 자유롭게 참여하고 의견을 남길 수 있습니다.
+
+- [카카오 오픈 톡방](https://open.kakao.com/o/gS5IxXxh) — 매주 공유되는 Zoom 링크로 입장
+
+---
+
+### 프로젝트 기여
+
+OWASP 내 다양한 오픈소스 프로젝트에 코드, 문서, 번역 등 다양한 방식으로 기여하거나 새 프로젝트를 시작할 수 있습니다. 프로젝트 운영 중 발생하는 비용(장소 대여, 인쇄물 등)은 **$250까지 사전 승인 없이** 영수증 제출만으로 청구 가능합니다.
+
+OWASP 프로젝트는 성숙도에 따라 세 가지로 구분됩니다.
+
+- ⭐ **Flagship** — OWASP 전략적 가치를 인정받은 최상위 프로젝트. 업계 표준으로 자리잡은 핵심 도구·문서들.
+- 🔧 **Production** — 실사용 가능한 완성도의 프로젝트. 활발히 유지보수되며 기여자를 환영.
+- 🌱 **Lab/Incubator** — 초기 단계의 실험적 프로젝트. 새로운 아이디어로 직접 시작할 수 있는 공간.
+
+주요 프로젝트 목록 ([전체 목록](https://owasp.org/projects/)):
+
+- ⭐ [OWASP Top Ten](https://owasp.org/www-project-top-ten/) — 가장 치명적인 웹 앱 보안 위험 10가지 목록 (업계 사실상 표준)
+- ⭐ [ASVS](https://owasp.org/www-project-application-security-verification-standard/) — 웹 앱 설계·개발·테스트 시 필요한 보안 요구사항 프레임워크
+- ⭐ [WSTG](https://owasp.org/www-project-web-security-testing-guide/) — 웹 애플리케이션 보안 테스팅의 교과서
+- ⭐ [Cheat Sheet Series](https://owasp.org/www-project-cheat-sheets/) — 개발자·방어자를 위한 보안 모범 사례 요약 가이드 모음
+- ⭐ [MAS](https://owasp.org/www-project-mobile-app-security/) — 모바일 앱 보안 표준·테스팅 가이드 종합 문서
+- 🔧 [API Security](https://owasp.org/www-project-api-security/) — API 고유 취약점과 보안 전략 가이드
+- 🔧 [Coraza WAF](https://owasp.org/www-project-coraza-web-application-firewall/) — Go 기반 엔터프라이즈급 WAF 프레임워크
+- 🔧 [Cornucopia](https://owasp.org/www-project-cornucopia/) — 위협 모델링을 게임처럼 진행하는 카드 게임
+- 🔧 [Threat Dragon](https://owasp.org/www-project-threat-dragon/) — 개발자·방어자용 위협 모델링 도구
+- 🔧 [Nest](https://nest.owasp.org) — OWASP 프로젝트·챕터·기여 기회를 통합 탐색할 수 있는 커뮤니티 게이트웨이
+
+
+한국인이 리드하는 OWASP 프로젝트 목록:
+
+**🌐 번역 프로젝트**
+
+OWASP 공식 프로젝트 리더 명단에는 번역 프로젝트가 별도로 등재되어 있지 않지만, Top Ten과 ASVS 등 주요 프로젝트 내에서 한국어 번역을 리드해 온 팀
+
+- 🔧 [OWASP Top Ten 한국어 번역](https://owasp.org/www-project-top-ten/) — 2010·2013·2017판 한국어 번역 프로젝트. 번역 프로젝트 관리 및 감수: 박형근(Hyungkeun Park)
+- 🔧 [ASVS 한국어 번역팀](https://owasp.org/www-project-application-security-verification-standard/) — ASVS 5.0 한국어 번역. 박우현(Park WooHyun) 외 18명 참여
+- 🔧 [Top 10 for LLM Applications 한국어 번역팀](https://owasp.org/www-project-top-10-for-large-language-model-applications/) — 한국어 번역팀 별도 운영 중
+
+**⭐ 공식 프로젝트 리더(Project Leader)가 한국인인 프로젝트**
+
+- 🌱 [OWASP Noir](https://owasp.org/www-project-noir/) — 코드 저장소를 분석해 모든 엔드포인트를 찾아내고 Shadow API·공격 표면을 매핑하는 SAST 도구. 리더: HAHWUL(이현환), KSG(김성기)
+- 🌱 [OWASP Vulnerable Container Hub](https://owasp.org/www-project-vulnerable-container-hub/) — 보안 트레이닝용 취약 컨테이너 모음 프로젝트. 리더: Jeremy Bonghwan Choi(최봉환)
+
+---
+
+### Working Group 열기
+
+특정 전략 목표 달성을 위한 한시적 작업반을 제안하고 운영할 수 있습니다. Chair(의장)는 OWASP 유료 멤버여야 하며, 일반 참여자는 멤버십 없이도 참여 가능합니다. Working Group 운영 중 발생하는 비용은 **$250까지 사전 승인 없이** 영수증 제출만으로 청구 가능합니다.
+
+- [Working Group 정책](https://policy.owasp.org/operational/working-groups) — 신청 조건 및 절차 안내
+
+---
+
+### 글로벌 이벤트 참여
+
+OWASP는 전 세계에서 다양한 컨퍼런스와 커뮤니티 이벤트를 개최합니다 ([전체 이벤트 목록](https://owasp.org/events/)).
+
+🌐 **Global Events**
+
+- [Global AppSec EU 2026](https://owasp.glueup.com/event/owasp-global-appsec-eu-2026-vienna-austria-162243/) — 2026.06.22–26, 오스트리아 빈. 800명+ 규모 유럽 최대 AppSec 컨퍼런스
+- [Global AppSec USA 2026](https://owasp.glueup.com/event/owasp-2026-global-appsec-usa-san-francisco-ca-167174/) — 2026.11.02–06, 미국 샌프란시스코. 트레이닝 3일 + 컨퍼런스 2일
+
+📅 **AppSec Days** (지역 챕터 주도 컨퍼런스)
+
+- [AppSec Italy Day 2026](https://owasp.org/www-chapter-italy/events/OWASPItalyDay2026-06-18) — 2026.06.17–18, 이탈리아 칼리아리. AI 보안·DevSecOps 중심 무료 컨퍼런스
+- [AppSec Days Portugal 2026](https://appsecdays.pt/) — 2026.09.23–24, 포르투갈. 400명+ 규모 2일 컨퍼런스
+- [German OWASP Day 2026](https://god.owasp.de/2026/) — 2026.09.23–24, 독일 카를스루에
+- [AppSec Days France 2026](https://www.owaspappsecdays.fr/2026/index.html) — 2026.09.24, 프랑스 파리. 유럽 전문가 150명+ 참가
+- [AppSec Israel 2026](https://appsecil.org/) — 2026.10.06, 이스라엘 텔아비브. 1,000명+ 참가, 무료 입장
+- [LASCON 2026](https://www.lascon.org) — 2026.10.27–30, 미국 오스틴
+- [BeNeLux Days 2026](https://2026.owaspbenelux.eu/) — 2026.11.26–27, 네덜란드. 컨퍼런스 무료, 트레이닝 €50
+- [AppSec Days India 2026](https://india.appsecdays.org/) — 2026.11.21–22, 온라인. 1,200명+ 버추얼 컨퍼런스
+- [OWASP BASC 2027](https://basconf.org/) — 2027.04.03, 미국 보스턴
+
+🌱 **Community Initiatives** (상시 참여 가능)
+
+- [Google Summer of Code (GSoC)](https://owasp.org/www-community/initiatives/gsoc/gsoc2026) — Google 주관 오픈소스 인턴십. 💰 학생 대상 스티펜드 지급: Small $750–$1,650 / Medium $1,500–$3,300 / Large $3,000–$6,600 (거주 국가 PPP 기준, 2회 분할 지급)
+- [Google Season of Docs (GSoD)](https://developers.google.com/season-of-docs/docs/) — 전문 기술 작가가 OWASP 프로젝트 문서 개선에 참여. 💰 조직에 $5,000–$15,000 그랜트 지급, 조직이 기술 작가를 직접 고용
+- [Code Sprint](https://owasp.org/www-community/initiatives/code_sprint/) — OWASP 자체 코드 스프린트. GSoC 형식으로 학생·커뮤니티에 실전 개발 경험 제공 (비정기 개최)
+- [OWASP Bug Bounty](https://owasp.org/www-community/initiatives/bugbounty/) — BugCrowd 연계 버그 바운티. 💰 OWASP 인프라 취약점 제보 시 심각도(P1–P5) 기준 현금 지급
+
+---
+
+### 후원
+
+- [후원 안내 페이지](https://owasp.org/www-chapter-seoul/#div-sponsors) — 단일 회의 후원 또는 연간 챕터 후원으로 OWASP 서울 챕터의 든든한 파트너가 되어주세요. 후원금은 세미나 장소 마련, 다과 준비 등 행사 운영에 투명하게 사용됩니다.
+
+---
+
+## 기여 유의사항
+
+OWASP는 비영리 단체로서 순수한 지식 공유와 커뮤니티 활성화를 최우선 가치로 삼고 있습니다.
+
+🚫 **상업적 발표 불가** — 특정 제품 판매를 목적으로 하는 발표는 허용되지 않습니다. 기술과 지식 공유 목적의 발표는 언제나 환영합니다.


### PR DESCRIPTION
## Why
OWASP Chapter Seoul 운영진 2026 6월 회의 결과 기여 활동 독려를 위한 한눈에 볼 수 있는 기여 활동 원페이지 가이드가 필요했습니다.

To encourage community members to get involved with OWASP Chapter Seoul, this PR adds a one-page guide summarizing the ways people can contribute.

## What
발표, 월간 회의 참여, 오픈소스 프로젝트 기여, Working Group 개설, 글로벌 이벤트 참여, 후원 등 다양한 기여 활동 종류와 참여 방법을 정리한 새 탭(`Contribution`)을 추가했습니다. 

Added a new "Contribution" tab covering ways to contribute: giving talks, joining monthly meetings, contributing to OWASP open-source projects, starting a working group, participating in global events, and sponsorship.


## Screenshot
<img width="948" height="479" alt="image" src="https://github.com/user-attachments/assets/70c8820c-7cb5-4761-a554-d5fd72eb99f6" />

## Checklist
- [x] Tested locally with `bundle exec jekyll serve`
- [x] Verified new tab renders correctly and appears in the correct position