### PR TITLE
Add new Seoul chapter leaders

### DIFF
--- a/leaders.md
+++ b/leaders.md
@@ -2,4 +2,5 @@
 
 * [Donghyun Kim](mailto:ben.kim@owasp.org) 
 * [Seongjin Hong](mailto:seongjin.hong@owasp.org)
-* [Hyunjeong Lee](mailto:hyunjeong.lee@owasp.org@owasp.org)
+* [Hyunjeong Lee](mailto:hyunjeong.lee@owasp.org)
+* [Shinwoo Kang](mailto:kang.shin.woo@owasp.org)

--- a/tab_seoul.md
+++ b/tab_seoul.md
@@ -23,6 +23,7 @@ OWASP Seoul Chapter 5기 운영진을 현재 아래와 같이 구성하여 운�
 운영진 참여, 회원 관련 및 기타 문의: [서울 리더](mailto:seoul-leaders@owasp.org)
 
 # OWASP Seoul Chapter 역대 운영진
+
 | 이름 | 소속 | Contact | Site | 활동내역 |
 | --- | --- | --- | --- | --- |
 | 전영재 | 에스알센터 | [LinkedIn](https://www.linkedin.com/in/whitehat-kr/) | | 서울 챕터 리더 (2019.03 ~ 2026.05) |

--- a/tab_seoul.md
+++ b/tab_seoul.md
@@ -17,6 +17,8 @@ OWASP Seoul Chapter 5기 운영진을 현재 아래와 같이 구성하여 운�
 | --- | --- | --- | --- | --- |
 | 홍성진 | Sendbird | [LinkedIn](https://www.linkedin.com/in/sjhk/) | [Blog](https://seongjin.blog) | 서울 챕터 리더 (2025.05 ~ ) |
 | 김동현 | Cremit | [LinkedIn](https://www.linkedin.com/in/ben-dh-kim/) | [Blog](https://bendh.kim) | 서울 챕터 리더 (2025.05 ~ ) |
+| 강신우 | LLOYDK | [LinkedIn](https://www.linkedin.com/in/kang-shin-woo/) | | 서울 챕터 리더 (2026.05 ~ ) |
+| 이현정 | IBM | [LinkedIn](https://www.linkedin.com/in/jlee0505/) | | 서울 챕터 리더 (2026.05 ~ ) |
 
 운영진 참여, 회원 관련 및 기타 문의: [서울 리더](mailto:seoul-leaders@owasp.org)
 


### PR DESCRIPTION
## Summary
- Add Shinwoo Kang and Hyunjeong Lee's full profile (LinkedIn, affiliation, activity) to the current leaders table
- Add Shinwoo Kang's email link and fix a duplicated domain in Hyunjeong Lee's mailto link
- Fix a missing blank line that broke the past leaders table rendering

## Test plan
- [x] Verified locally with `bundle exec jekyll serve` that both leader tables render correctly