### PR TITLE
docs: update 2026 Seoul chapter leaders info

### DIFF
--- a/tab_seoul.md
+++ b/tab_seoul.md
@@ -15,7 +15,7 @@ OWASP Seoul Chapter 5기 운영진을 현재 아래와 같이 구성하여 운�
 
 | 이름 | 소속 | Contact | Site | 활동내역 |
 | --- | --- | --- | --- | --- |
-| 홍성진 | Sendbird | [LinkedIn](https://www.linkedin.com/in/sjhk/) | [Blog](https://seongjin.blog) | 서울 챕터 리더 (2025.05 ~ ) |
+| 홍성진 | XBOW | [LinkedIn](https://www.linkedin.com/in/sjhk/) | [Blog](https://seongjin.blog) | 서울 챕터 리더 (2025.05 ~ ) |
 | 김동현 | Cremit | [LinkedIn](https://www.linkedin.com/in/ben-dh-kim/) | [Blog](https://bendh.kim) | 서울 챕터 리더 (2025.05 ~ ) |
 | 강신우 | LLOYDK | [LinkedIn](https://www.linkedin.com/in/kang-shin-woo/) | | 서울 챕터 리더 (2026.05 ~ ) |
 | 이현정 | IBM | [LinkedIn](https://www.linkedin.com/in/jlee0505/) | | 서울 챕터 리더 (2026.05 ~ ) |


### PR DESCRIPTION
## Summary
- Add new Seoul chapter leaders
- Fix missing blank line before past leaders table
- Update Seongjin Hong's affiliation to XBOW